### PR TITLE
test pr w/ circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 # https://discuss.circleci.com/t/requesterror-x509-certificate-signed-by-unknown-authority-while-uploading-workspace/27908/2
 # https://support.circleci.com/hc/en-us/articles/360016505753-Resolve-Certificate-Signed-By-Unknown-Authority-error-in-Alpine-images?flash_digest=39b76521a337cecacac0cc10cb28f3747bb5fc6a
 executors:
-  testecutor:
+  default-executor:
     docker:
       # Do not lead with alpine images if using 'persist_to_workspace'
       - image: circleci/openjdk:8-jdk-stretch
@@ -19,7 +19,7 @@ orbs:
   codecov: codecov/codecov@1.0.4
 jobs:
   checkout:
-    executor: testecutor
+    executor: default-executor
     steps:
       - checkout
       - attach_workspace:
@@ -29,7 +29,7 @@ jobs:
           paths:
             - '*'
   pr_checkout:
-    executor: testecutor
+    executor: default-executor
     steps:
       - run:
           name: Get PR target branch.
@@ -46,7 +46,7 @@ jobs:
           paths:
             - '*'
   build:
-    executor: testecutor
+    executor: default-executor
     steps:
       - attach_workspace:
           at: ~/circleci-demo-java-spring
@@ -70,12 +70,12 @@ jobs:
           file: src/target/jacoco-reports
 workflows:
   version: 2
-  # branch_build:
-    # jobs:
-      # - checkout
-      # - build:
-          # requires:
-            # - checkout
+  branch_build:
+    jobs:
+      - checkout
+      - build:
+          requires:
+            - checkout
   pr_build:
     jobs:
       - pr_checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,8 +54,6 @@ workflows:
   branch_build:
     jobs:
       - checkout
-      - build
-  pr_build:
-    jobs:
-      - pr_checkout
-      - build
+      - build:
+        requires:
+          - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,19 @@ version: 2.1
 orbs:
   codecov: codecov/codecov@1.0.4
 jobs:
+  checkout:
+    steps:
+      - checkout
+  pr_checkout:
+    steps:
+      - run:
+          name: Get PR target branch.
+          command: |
+            CIRCLECI_TARGET_BRANCH=$(curl -s https://api.github.com/repos/deeteecee/circleci-demo-java-spring/pulls/1 | jq --raw-output '.base.ref')
+            echo "Github target branch: $CIRCLECI_TARGET_BRANCH"
+      - checkout
+      - run: git merge $CIRCLECI_TARGET_BRANCH
   build:
-    
     working_directory: ~/circleci-demo-java-spring
 
     docker:
@@ -14,9 +25,6 @@ jobs:
           POSTGRES_DB: circle_test
 
     steps:
-
-      - checkout
-
       - restore_cache:
           key: circleci-demo-java-spring-{{ checksum "pom.xml" }}
       
@@ -35,3 +43,11 @@ jobs:
       - codecov/upload:
           conf: codecov.yml 
           file: src/target/jacoco-reports
+workflows:
+  version: 2
+  branch_build:
+    - checkout
+    - build
+  pr_build:
+    - pr_checkout
+    - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - persist_to_workspace:
           root: ~/
           paths:
-            - circleci-demo-java-spring
+            - '*'
   pr_checkout:
     executor: testecutor
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,5 @@
 version: 2.1
+# https://github.com/CircleCI-Public/circleci-demo-workflows/blob/workspace-forwarding/.circleci/config.yml
 # persist_to_workspace issues?
 # https://discuss.circleci.com/t/requesterror-x509-certificate-signed-by-unknown-authority-while-uploading-workspace/27908/2
 # https://support.circleci.com/hc/en-us/articles/360016505753-Resolve-Certificate-Signed-By-Unknown-Authority-error-in-Alpine-images?flash_digest=39b76521a337cecacac0cc10cb28f3747bb5fc6a
@@ -37,10 +38,12 @@ jobs:
             echo "Github target branch: $CIRCLECI_TARGET_BRANCH"
       - checkout
       - run: git merge $CIRCLECI_TARGET_BRANCH
+      - attach_workspace:
+          at: ~/circleci-demo-java-spring
       - persist_to_workspace:
-          root: /root
+          root: .
           paths:
-            - circleci-demo-java-spring
+            - '*'
   build:
     executor: testecutor
     steps:
@@ -72,3 +75,9 @@ workflows:
       - build:
           requires:
             - checkout
+  pr_build:
+    jobs:
+      - pr_checkout
+      - build:
+          requires:
+            - pr_checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,8 @@ jobs:
     executor: testecutor
     steps:
       - checkout
+      - attach_workspace:
+          at: ~/circleci-demo-java-spring
       - persist_to_workspace:
           root: .
           paths:
@@ -42,6 +44,8 @@ jobs:
   build:
     executor: testecutor
     steps:
+      - attach_workspace:
+          at: ~/circleci-demo-java-spring
       - restore_cache:
           key: circleci-demo-java-spring-{{ checksum "pom.xml" }}
       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,10 @@ jobs:
     executor: testecutor
     steps:
       - checkout
+      - persist_to_workspace:
+          root: /root
+          paths:
+            - circleci-demo-java-spring
   pr_checkout:
     executor: testecutor
     steps:
@@ -28,6 +32,10 @@ jobs:
             echo "Github target branch: $CIRCLECI_TARGET_BRANCH"
       - checkout
       - run: git merge $CIRCLECI_TARGET_BRANCH
+      - persist_to_workspace:
+          root: /root
+          paths:
+            - circleci-demo-java-spring
   build:
     executor: testecutor
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,5 +55,5 @@ workflows:
     jobs:
       - checkout
       - build:
-        requires:
-          - checkout
+          requires:
+            - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,9 @@ version: 2.1
 executors:
   testecutor:
     docker:
-      - image: nimmis/jq
       - image: circleci/openjdk:8-jdk-stretch
       - image: circleci/postgres:9.6.3-alpine
+      - image: nimmis/jq
         environment:
           POSTGRES_USER: root
           POSTGRES_DB: circle_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - persist_to_workspace:
           root: ~/
           paths:
-            - '*'
+            - .
   pr_checkout:
     executor: testecutor
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,9 +22,9 @@ jobs:
     steps:
       - checkout
       - persist_to_workspace:
-          root: ~/
+          root: .
           paths:
-            - .
+            - '*'
   pr_checkout:
     executor: testecutor
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,14 @@
 version: 2.1
-
+# persist_to_workspace issues?
+# https://discuss.circleci.com/t/requesterror-x509-certificate-signed-by-unknown-authority-while-uploading-workspace/27908/2
+# https://support.circleci.com/hc/en-us/articles/360016505753-Resolve-Certificate-Signed-By-Unknown-Authority-error-in-Alpine-images?flash_digest=39b76521a337cecacac0cc10cb28f3747bb5fc6a
 executors:
   testecutor:
     docker:
+      # Do not lead with alpine images if using 'persist_to_workspace'
       - image: circleci/openjdk:8-jdk-stretch
       - image: circleci/postgres:9.6.3-alpine
-      - image: nimmis/jq
+      - image: nimmis/jq 
         environment:
           POSTGRES_USER: root
           POSTGRES_DB: circle_test
@@ -19,7 +22,7 @@ jobs:
     steps:
       - checkout
       - persist_to_workspace:
-          root: /root
+          root: ~/
           paths:
             - circleci-demo-java-spring
   pr_checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,8 +37,11 @@ jobs:
             echo "export CIRCLECI_TARGET_BRANCH=$(curl -s https://api.github.com/repos/deeteecee/circleci-demo-java-spring/pulls/1 | jq --raw-output '.base.ref')" >> $BASH_ENV
             echo "Github target branch: $CIRCLECI_TARGET_BRANCH"
       - checkout
-      - run: git fetch
+      # Test the PR merge manually. 
+      - run: git fetch origin
       - run: git merge $CIRCLECI_TARGET_BRANCH
+      - run: git checkout master
+      - run: git merge --no-ff branch
       - attach_workspace:
           at: ~/circleci-demo-java-spring
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,25 @@
 version: 2.1
+
+executors:
+  testecutor:
+    docker:
+      - image: nimmis/jq
+      - image: circleci/openjdk:8-jdk-stretch
+      - image: circleci/postgres:9.6.3-alpine
+        environment:
+          POSTGRES_USER: root
+          POSTGRES_DB: circle_test
+    working_directory: ~/circleci-demo-java-spring
+
 orbs:
   codecov: codecov/codecov@1.0.4
 jobs:
   checkout:
+    executor: testecutor
     steps:
       - checkout
   pr_checkout:
+    executor: testecutor
     steps:
       - run:
           name: Get PR target branch.
@@ -15,15 +29,7 @@ jobs:
       - checkout
       - run: git merge $CIRCLECI_TARGET_BRANCH
   build:
-    working_directory: ~/circleci-demo-java-spring
-
-    docker:
-      - image: circleci/openjdk:8-jdk-stretch
-      - image: circleci/postgres:9.6.3-alpine
-        environment:
-          POSTGRES_USER: root
-          POSTGRES_DB: circle_test
-
+    executor: testecutor
     steps:
       - restore_cache:
           key: circleci-demo-java-spring-{{ checksum "pom.xml" }}
@@ -46,8 +52,10 @@ jobs:
 workflows:
   version: 2
   branch_build:
-    - checkout
-    - build
+    jobs:
+      - checkout
+      - build
   pr_build:
-    - pr_checkout
-    - build
+    jobs:
+      - pr_checkout
+      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,8 @@ jobs:
             - run:
                 name: Get PR target branch.
                 command: |
-                  echo "export CIRCLECI_TARGET_BRANCH=$(curl -s https://api.github.com/repos/deeteecee/circleci-demo-java-spring/pulls/1 | jq --raw-output '.base.ref')" >> $BASH_ENV
+                  CIRCLECI_TARGET_BRANCH=$(curl -s https://api.github.com/repos/deeteecee/circleci-demo-java-spring/pulls/1 | jq --raw-output '.base.ref')
+                  echo 'export CIRCLECI_TARGET_BRANCH="${CIRCLECI_TARGET_BRANCH}"' >> $BASH_ENV
                   echo "Github target branch: $CIRCLECI_TARGET_BRANCH"
             # Test the PR merge manually. 
             - run: git fetch origin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ jobs:
             CIRCLECI_TARGET_BRANCH=$(curl -s https://api.github.com/repos/deeteecee/circleci-demo-java-spring/pulls/1 | jq --raw-output '.base.ref')
             echo "Github target branch: $CIRCLECI_TARGET_BRANCH"
       - checkout
+      - run: git fetch
       - run: git merge $CIRCLECI_TARGET_BRANCH
       - attach_workspace:
           at: ~/circleci-demo-java-spring
@@ -69,12 +70,12 @@ jobs:
           file: src/target/jacoco-reports
 workflows:
   version: 2
-  branch_build:
-    jobs:
-      - checkout
-      - build:
-          requires:
-            - checkout
+  # branch_build:
+    # jobs:
+      # - checkout
+      # - build:
+          # requires:
+            # - checkout
   pr_build:
     jobs:
       - pr_checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,30 +18,27 @@ executors:
 orbs:
   codecov: codecov/codecov@1.0.4
 jobs:
-  checkout:
+  checkout-job:
     executor: default-executor
+    parameters:
+      is-merge: # do a prospective merge with master test
+        type: boolean
+        default: false
     steps:
       - checkout
-      - attach_workspace:
-          at: ~/circleci-demo-java-spring
-      - persist_to_workspace:
-          root: .
-          paths:
-            - '*'
-  pr_checkout:
-    executor: default-executor
-    steps:
-      - run:
-          name: Get PR target branch.
-          command: |
-            echo "export CIRCLECI_TARGET_BRANCH=$(curl -s https://api.github.com/repos/deeteecee/circleci-demo-java-spring/pulls/1 | jq --raw-output '.base.ref')" >> $BASH_ENV
-            echo "Github target branch: $CIRCLECI_TARGET_BRANCH"
-      - checkout
-      # Test the PR merge manually. 
-      - run: git fetch origin
-      - run: git merge $CIRCLECI_TARGET_BRANCH
-      - run: git checkout master
-      - run: git merge --no-ff branch
+      - when:
+          condition: << parameters.is-merge >> 
+          steps:
+            - run:
+                name: Get PR target branch.
+                command: |
+                  echo "export CIRCLECI_TARGET_BRANCH=$(curl -s https://api.github.com/repos/deeteecee/circleci-demo-java-spring/pulls/1 | jq --raw-output '.base.ref')" >> $BASH_ENV
+                  echo "Github target branch: $CIRCLECI_TARGET_BRANCH"
+            # Test the PR merge manually. 
+            - run: git fetch origin
+            - run: git merge $CIRCLECI_TARGET_BRANCH
+            - run: git checkout master
+            - run: git merge --no-ff branch
       - attach_workspace:
           at: ~/circleci-demo-java-spring
       - persist_to_workspace:
@@ -73,15 +70,16 @@ jobs:
           file: src/target/jacoco-reports
 workflows:
   version: 2
-  branch_build:
+  test:
     jobs:
-      - checkout
+      - checkout-job
       - build:
           requires:
-            - checkout
-  pr_build:
+            - checkout-job
+  merge-test:
     jobs:
-      - pr_checkout
+      - checkout-job:
+          is-merge: true
       - build:
           requires:
-            - pr_checkout
+            - checkout-job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,6 @@ jobs:
             - run: git merge $CIRCLECI_TARGET_BRANCH
             - run: git checkout master
             - run: git merge --no-ff branch
-      - attach_workspace:
-          at: ~/circleci-demo-java-spring
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
       - run:
           name: Get PR target branch.
           command: |
-            CIRCLECI_TARGET_BRANCH=$(curl -s https://api.github.com/repos/deeteecee/circleci-demo-java-spring/pulls/1 | jq --raw-output '.base.ref')
+            echo "export CIRCLECI_TARGET_BRANCH=$(curl -s https://api.github.com/repos/deeteecee/circleci-demo-java-spring/pulls/1 | jq --raw-output '.base.ref')" >> $BASH_ENV
             echo "Github target branch: $CIRCLECI_TARGET_BRANCH"
       - checkout
       - run: git fetch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,7 @@ jobs:
             - run:
                 name: Get PR target branch.
                 command: |
-                  CIRCLECI_TARGET_BRANCH=$(curl -s https://api.github.com/repos/deeteecee/circleci-demo-java-spring/pulls/1 | jq --raw-output '.base.ref')
-                  echo 'export CIRCLECI_TARGET_BRANCH="${CIRCLECI_TARGET_BRANCH}"' >> $BASH_ENV
+                  echo $"export CIRCLECI_TARGET_BRANCH=\"$(curl -s https://api.github.com/repos/deeteecee/circleci-demo-java-spring/pulls/1 | jq --raw-output '.base.ref')\"" >> $BASH_ENV
                   echo "Github target branch: $CIRCLECI_TARGET_BRANCH"
             # Test the PR merge manually. 
             - run: git fetch origin

--- a/src/test/java/com/circleci/demojavaspring/DemoJavaSpringApplicationTests.java
+++ b/src/test/java/com/circleci/demojavaspring/DemoJavaSpringApplicationTests.java
@@ -9,4 +9,8 @@ public class DemoJavaSpringApplicationTests {
 	public void contextLoads() {
 	}
 
+    @Test
+    public void newTestOne() {
+        
+    }
 }


### PR DESCRIPTION
This is just a PoC for running a feature that's missing in CircleCI and other CI tools. The feature is offered, for example, in TravisCI where you have tests that happen in merges: https://docs.travis-ci.com/user/pull-requests/

I think the short explanation is a lot of weird things happen during merges and this extra PR test is a lifesaver for preventing unwanted merge results from failing. 

